### PR TITLE
Implement csv-feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ test {
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.5.10'
 //    compile 'org.codehaus.groovy:groovy-all:3.0.2' // still buggy
+    compile group: 'org.apache.commons', name: 'commons-csv', version: '1.8'
 
     compile 'org.codehaus.gpars:gpars:1.2.1'
     compile 'org.apache.commons:commons-lang3:3.9'

--- a/src/main/groovy/cz/siret/prank/features/api/FeatureRegistry.groovy
+++ b/src/main/groovy/cz/siret/prank/features/api/FeatureRegistry.groovy
@@ -1,9 +1,6 @@
 package cz.siret.prank.features.api
 
 
-import cz.siret.prank.features.api.FeatureCalculator
-import cz.siret.prank.features.api.ResidueToAtomicFeatWrapper
-import cz.siret.prank.features.api.ResidueToSasFeatWrapper
 import cz.siret.prank.features.implementation.AAIndexFeature
 import cz.siret.prank.features.implementation.Asa2Feature
 import cz.siret.prank.features.implementation.AsaFeature
@@ -19,7 +16,7 @@ import cz.siret.prank.features.implementation.ProtrusionHistogramFeature
 import cz.siret.prank.features.implementation.PyramidFeature
 import cz.siret.prank.features.implementation.conservation.ConservCloudSF
 import cz.siret.prank.features.implementation.conservation.ConservRF
-import cz.siret.prank.features.implementation.external.CsvFileAtomFeature
+import cz.siret.prank.features.implementation.external.CsvFileFeature
 import cz.siret.prank.features.implementation.residue.ContactResiduesRF
 import cz.siret.prank.features.implementation.secstruct.SecStructCloudSF
 import cz.siret.prank.features.implementation.secstruct.SecStructRF
@@ -103,7 +100,7 @@ class FeatureRegistry {
         register new ResidueToAtomicFeatWrapper(new ConservRF())
         register new ConservCloudSF()
 
-        register new CsvFileAtomFeature()
+        register new CsvFileFeature()
 
         // Register new feature implementations here
 

--- a/src/main/groovy/cz/siret/prank/features/api/FeatureRegistry.groovy
+++ b/src/main/groovy/cz/siret/prank/features/api/FeatureRegistry.groovy
@@ -19,6 +19,7 @@ import cz.siret.prank.features.implementation.ProtrusionHistogramFeature
 import cz.siret.prank.features.implementation.PyramidFeature
 import cz.siret.prank.features.implementation.conservation.ConservCloudSF
 import cz.siret.prank.features.implementation.conservation.ConservRF
+import cz.siret.prank.features.implementation.external.CsvFileAtomFeature
 import cz.siret.prank.features.implementation.residue.ContactResiduesRF
 import cz.siret.prank.features.implementation.secstruct.SecStructCloudSF
 import cz.siret.prank.features.implementation.secstruct.SecStructRF
@@ -101,6 +102,8 @@ class FeatureRegistry {
         register new ResidueToSasFeatWrapper(new ConservRF())
         register new ResidueToAtomicFeatWrapper(new ConservRF())
         register new ConservCloudSF()
+
+        register new CsvFileAtomFeature()
 
         // Register new feature implementations here
 

--- a/src/main/groovy/cz/siret/prank/features/implementation/external/CsvFileAtomFeature.groovy
+++ b/src/main/groovy/cz/siret/prank/features/implementation/external/CsvFileAtomFeature.groovy
@@ -1,0 +1,62 @@
+package cz.siret.prank.features.implementation.external;
+
+import cz.siret.prank.domain.Protein;
+import cz.siret.prank.features.api.AtomFeatureCalculationContext;
+import cz.siret.prank.features.api.AtomFeatureCalculator;
+import cz.siret.prank.features.api.ProcessedItemContext;
+import cz.siret.prank.program.params.Parametrized;
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j;
+import org.biojava.nbio.structure.Atom
+
+@Slf4j
+@CompileStatic
+class CsvFileAtomFeature extends AtomFeatureCalculator implements Parametrized {
+
+    private static final String DATA_LOADED_KEY = "CSV_FILE_DATA_LOADED";
+
+    private static final String DATA_KEY = "CSV_FILE_DATA";
+
+    @Override
+    public String getName() {
+        return "csv_file_atom_feature";
+    }
+
+    @Override
+    public void preProcessProtein(
+            Protein protein,
+            ProcessedItemContext context) {
+        super.preProcessProtein(protein, context);
+        ensureCsvFileForProteinIsLoaded(protein);
+    }
+
+    private void ensureCsvFileForProteinIsLoaded(Protein protein) {
+        if (protein.getSecondaryData().get(DATA_LOADED_KEY) == Boolean.TRUE) {
+            return;
+        }
+        loadCsvFileForProtein(protein);
+    }
+
+    private void loadCsvFileForProtein(Protein protein) {
+        List<String> directories = getParams().csv_file_feature_directories;
+        ExternalAtomFeature feature = new ExternalAtomFeature();
+        feature.load(directories, protein.name);
+        Map<String, Object> secondaryData = protein.getSecondaryData();
+        secondaryData.put(DATA_LOADED_KEY, true);
+        secondaryData.put(DATA_KEY, feature);
+    }
+
+    @Override
+    public double[] calculateForAtom(
+            Atom proteinSurfaceAtom,
+            AtomFeatureCalculationContext context) {
+        ExternalAtomFeature feature = getFeature(context.protein);
+        return feature.getValue(proteinSurfaceAtom);
+    }
+
+
+    private static ExternalAtomFeature getFeature(Protein protein) {
+        return (ExternalAtomFeature)protein.getSecondaryData().get(DATA_KEY);
+    }
+
+}

--- a/src/main/groovy/cz/siret/prank/features/implementation/external/CsvFileAtomFeature.groovy
+++ b/src/main/groovy/cz/siret/prank/features/implementation/external/CsvFileAtomFeature.groovy
@@ -3,11 +3,14 @@ package cz.siret.prank.features.implementation.external;
 import cz.siret.prank.domain.Protein;
 import cz.siret.prank.features.api.AtomFeatureCalculationContext;
 import cz.siret.prank.features.api.AtomFeatureCalculator;
-import cz.siret.prank.features.api.ProcessedItemContext;
+import cz.siret.prank.features.api.ProcessedItemContext
+import cz.siret.prank.features.implementation.conservation.ConservationScore
+import cz.siret.prank.program.PrankException;
 import cz.siret.prank.program.params.Parametrized;
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j;
 import org.biojava.nbio.structure.Atom
+import org.biojava.nbio.structure.Group
 
 @Slf4j
 @CompileStatic
@@ -56,7 +59,7 @@ class CsvFileAtomFeature extends AtomFeatureCalculator implements Parametrized {
 
 
     private static ExternalAtomFeature getFeature(Protein protein) {
-        return (ExternalAtomFeature)protein.getSecondaryData().get(DATA_KEY);
+        return (ExternalAtomFeature) protein.getSecondaryData().get(DATA_KEY);
     }
 
 }

--- a/src/main/groovy/cz/siret/prank/features/implementation/external/CsvFileFeature.groovy
+++ b/src/main/groovy/cz/siret/prank/features/implementation/external/CsvFileFeature.groovy
@@ -4,17 +4,14 @@ import cz.siret.prank.domain.Protein;
 import cz.siret.prank.features.api.AtomFeatureCalculationContext;
 import cz.siret.prank.features.api.AtomFeatureCalculator;
 import cz.siret.prank.features.api.ProcessedItemContext
-import cz.siret.prank.features.implementation.conservation.ConservationScore
-import cz.siret.prank.program.PrankException;
 import cz.siret.prank.program.params.Parametrized;
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j;
 import org.biojava.nbio.structure.Atom
-import org.biojava.nbio.structure.Group
 
 @Slf4j
 @CompileStatic
-class CsvFileAtomFeature extends AtomFeatureCalculator implements Parametrized {
+class CsvFileFeature extends AtomFeatureCalculator implements Parametrized {
 
     private static final String DATA_LOADED_KEY = "CSV_FILE_DATA_LOADED";
 
@@ -22,7 +19,7 @@ class CsvFileAtomFeature extends AtomFeatureCalculator implements Parametrized {
 
     @Override
     public String getName() {
-        return "csv_file_atom_feature";
+        return "csv_file_feature";
     }
 
     @Override
@@ -41,7 +38,7 @@ class CsvFileAtomFeature extends AtomFeatureCalculator implements Parametrized {
     }
 
     private void loadCsvFileForProtein(Protein protein) {
-        List<String> directories = getParams().csv_file_feature_directories;
+        List<String> directories = getParams().feat_csv_directories;
         ExternalAtomFeature feature = new ExternalAtomFeature();
         feature.load(directories, protein.name);
         Map<String, Object> secondaryData = protein.getSecondaryData();

--- a/src/main/groovy/cz/siret/prank/features/implementation/external/ExternalAtomFeature.groovy
+++ b/src/main/groovy/cz/siret/prank/features/implementation/external/ExternalAtomFeature.groovy
@@ -1,0 +1,252 @@
+package cz.siret.prank.features.implementation.external
+
+import cz.siret.prank.program.PrankException
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVRecord;
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.ResidueNumber
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * We expect in each directory file with same name as protein but with added
+ * ".csv" extension.
+ */
+@Slf4j
+@CompileStatic
+public class ExternalAtomFeature {
+
+    private static String PDB_SERIAL_COLUMN = "pdb serial";
+
+    private static String CHAIN_COLUMN = "chain";
+
+    private static String INS_CODE_COLUMN = "ins. code";
+
+    private static String SEQ_CODE_COLUMN = "seq. code";
+
+    private static String IGNORE_COLUMN_PREFIX = "#";
+
+    private static List<String> RESIDUE_HEADER =
+            Arrays.asList(CHAIN_COLUMN, INS_CODE_COLUMN, SEQ_CODE_COLUMN);
+
+    private static enum CsvFileType {
+        AtomCsv,
+        ResidueCsv
+    }
+
+    private static class FileMetadata {
+
+        public CsvFileType type;
+
+        public List<Integer> valueColumns = new ArrayList<>();
+
+    }
+
+    private Map<String, List<Double>> atomFeatures = new HashMap<>();
+
+    private Map<ResidueNumber, List<Double>> residueFeatures = new HashMap<>();
+
+    private int totalAtomFeatureSize = 0;
+
+    private int totalResidueFeatureSize = 0;
+
+    private Map<String, FileMetadata> directoryMetadata = new HashMap<>();
+
+    public void load(List<String> directories, String fileName) {
+        ensureMetadataAreLoaded(directories, fileName);
+        for (String dir in directories) {
+            String path = dir + File.separator + fileName + ".csv";
+            loadCsv(new File(path), directoryMetadata.get(dir));
+        }
+        validate();
+        // TODO We should validate that all features has same size !
+    }
+
+    private void ensureMetadataAreLoaded(
+            List<String> directories, String fileName) {
+        directoryMetadata = new HashMap<>();
+        for (String dir in directories) {
+            if (directoryMetadata.containsKey(dir)) {
+                continue;
+            }
+            File path = new File(dir, fileName + ".csv");
+            FileMetadata metadata = loadCsvMetadata(path);
+            directoryMetadata.put(dir, metadata);
+            switch (metadata.type) {
+                case CsvFileType.AtomCsv:
+                    totalAtomFeatureSize += metadata.valueColumns.size();
+                    break;
+                case CsvFileType.ResidueCsv:
+                    totalResidueFeatureSize += metadata.valueColumns.size();
+                    break;
+                default:
+                    throw new PrankException("Unknown file type.");
+            }
+        }
+    }
+
+    private static FileMetadata loadCsvMetadata(File file) {
+        FileInputStream stream = new FileInputStream(file);
+        List<String> headers;
+        try {
+            InputStreamReader input = new InputStreamReader(
+                    stream, StandardCharsets.UTF_8);
+            CSVParser csvParser =
+                    CSVFormat.RFC4180.withFirstRecordAsHeader().parse(input);
+            headers = csvParser.getHeaderNames();
+        } finally {
+            stream.close();
+        }
+        if (headers.contains(PDB_SERIAL_COLUMN)) {
+            FileMetadata result = new FileMetadata();
+            result.type = CsvFileType.AtomCsv;
+            for (int index = 0; index < headers.size(); ++index) {
+                String colName = headers.get(index);
+                if (colName.startsWith(IGNORE_COLUMN_PREFIX)) {
+                    continue;
+                }
+                if (PDB_SERIAL_COLUMN == colName) {
+                    continue;
+                }
+                result.valueColumns.add(index);
+            }
+            return result;
+        } else if (headers.containsAll(RESIDUE_HEADER)) {
+            FileMetadata result = new FileMetadata();
+            result.type = CsvFileType.ResidueCsv;
+            for (int index = 0; index < headers.size(); ++index) {
+                String colName = headers.get(index);
+                if (colName.startsWith(IGNORE_COLUMN_PREFIX)) {
+                    continue;
+                }
+                if (RESIDUE_HEADER.contains(colName)) {
+                    continue;
+                }
+                result.valueColumns.add(index);
+            }
+            return result;
+        } else {
+            throw new PrankException(
+                    "Can't recognize CSV header for: " + file)
+        }
+    }
+
+    private void loadCsv(File file, FileMetadata metadata) {
+        FileInputStream stream = new FileInputStream(file);
+        try {
+            InputStreamReader input = new InputStreamReader(
+                    stream, StandardCharsets.UTF_8);
+            CSVParser csvParser =
+                    CSVFormat.RFC4180.withFirstRecordAsHeader().parse(input);
+            // Determine type of CSV file using information about header.
+            switch (metadata.type) {
+                case CsvFileType.AtomCsv:
+                    loadAtomFeatureCsv(csvParser, metadata.valueColumns);
+                    break;
+                case CsvFileType.ResidueCsv:
+                    loadResidueFeatureCsv(csvParser, metadata.valueColumns);
+                    break;
+                default:
+                    throw new PrankException("Unknown file type for: " + file);
+            }
+
+        } finally {
+            stream.close();
+        }
+    }
+
+    private void loadAtomFeatureCsv(
+            CSVParser csvParser, List<Integer> valueColumns) {
+        for (CSVRecord record : csvParser) {
+            String key = record.get(PDB_SERIAL_COLUMN);
+            if (!atomFeatures.containsKey(key)) {
+                atomFeatures.put(key, new ArrayList<>());
+            }
+            readToList(record, valueColumns, atomFeatures.get(key));
+        }
+    }
+
+    private static void readToList(
+            CSVRecord record, List<Integer> columns, List<Double> target) {
+        for (int index : columns) {
+            target.add(Double.parseDouble(record.get(index)));
+        }
+    }
+
+    private void loadResidueFeatureCsv(
+            CSVParser csvParser, List<Integer> valueColumns) {
+        for (CSVRecord record : csvParser) {
+            String chain = record.get(CHAIN_COLUMN);
+            Integer seqCode = Integer.parseInt(record.get(SEQ_CODE_COLUMN));
+            String insCodeStr = record.get(INS_CODE_COLUMN);
+            Character insCode = null;
+            if (!insCodeStr.isAllWhitespace()) {
+                char[] chars = record.get(INS_CODE_COLUMN).getChars();
+                if (chars.length > 0) {
+                    insCode = Character.valueOf(chars[0]);
+                }
+            }
+            ResidueNumber key = new ResidueNumber(chain, seqCode, insCode);
+            if (!residueFeatures.containsKey(key)) {
+                residueFeatures.put(key, new ArrayList<>());
+            }
+            readToList(record, valueColumns, residueFeatures.get(key));
+        }
+    }
+
+    private void validate() {
+        for (Map.Entry<String, List<Double>> entry : atomFeatures.entrySet()) {
+            if (entry.value.size() != totalAtomFeatureSize) {
+                throw new PrankException(
+                        "Invalid atom feature size for ${entry.key}" +
+                                " of ${entry.value.size()} " +
+                                "expected ${totalAtomFeatureSize}")
+            }
+        }
+        for (Map.Entry<ResidueNumber, List<Double>> entry :
+                residueFeatures.entrySet()) {
+            if (entry.value.size() != totalResidueFeatureSize) {
+                throw new PrankException(
+                        "Invalid residue feature size for ${entry.key}" +
+                                " of ${entry.value.size()} " +
+                                "expected ${totalResidueFeatureSize}")
+            }
+        }
+    }
+
+    public double[] getValue(Atom atom) {
+        double[] result =
+                new double[totalAtomFeatureSize + totalResidueFeatureSize];
+        int pdbSerial = atom.getPDBserial();
+        if (atomFeatures.size() > 0) {
+            double[] atomFeature = atomFeatures.get(pdbSerial);
+            if (atomFeature == null) {
+                throw new PrankException(
+                        "Missing atom feature for: ${pdbSerial}");
+            }
+            copyToArray(atomFeature, result, 0);
+        }
+        ResidueNumber residueNumber = atom.getGroup().getResidueNumber();
+        if (residueFeatures.size() > 0) {
+            double[] residueFeature = residueFeatures.get(residueNumber);
+            if (residueFeature == null) {
+                throw new PrankException(
+                        "Missing residue for: ${residueNumber.chainId}" +
+                                " ${residueNumber.insCode}" +
+                                " ${residueNumber.seqNum} ");
+            }
+            copyToArray(residueFeature, result, totalAtomFeatureSize);
+        }
+        return result;
+    }
+
+    private static void copyToArray(double[] from, double[] to, int offset) {
+        for (int index = 0; index < from.length; ++index) {
+            to[index + offset] = from[index];
+        }
+    }
+
+}

--- a/src/main/groovy/cz/siret/prank/features/implementation/external/ExternalAtomFeature.groovy
+++ b/src/main/groovy/cz/siret/prank/features/implementation/external/ExternalAtomFeature.groovy
@@ -61,8 +61,7 @@ public class ExternalAtomFeature {
             String path = dir + File.separator + fileName + ".csv";
             loadCsv(new File(path), directoryMetadata.get(dir));
         }
-        validate();
-        // TODO We should validate that all features has same size !
+        validate(directories, fileName);
     }
 
     private void ensureMetadataAreLoaded(
@@ -197,7 +196,7 @@ public class ExternalAtomFeature {
         }
     }
 
-    private void validate() {
+    private void validate(List<String> directories, String fileName) {
         for (Map.Entry<String, List<Double>> entry : atomFeatures.entrySet()) {
             if (entry.value.size() != totalAtomFeatureSize) {
                 throw new PrankException(
@@ -214,6 +213,10 @@ public class ExternalAtomFeature {
                                 " of ${entry.value.size()} " +
                                 "expected ${totalResidueFeatureSize}")
             }
+        }
+        if (totalResidueFeatureSize + totalAtomFeatureSize == 0) {
+            throw new PrankException(
+                    "No features loaded for: ${fileName} from ${directories}");
         }
     }
 

--- a/src/main/groovy/cz/siret/prank/program/params/Params.groovy
+++ b/src/main/groovy/cz/siret/prank/program/params/Params.groovy
@@ -1052,6 +1052,12 @@ class Params {
     @RuntimeParam
     int use_kdtree_cutout_sphere_thrashold = 150
 
+    /**
+     * Used by csv_file_atom_feature.
+     */
+    @RuntimeParam
+    List<String> csv_file_feature_directories = [];
+
 //===========================================================================================================//
 
     /**

--- a/src/main/groovy/cz/siret/prank/program/params/Params.groovy
+++ b/src/main/groovy/cz/siret/prank/program/params/Params.groovy
@@ -1056,7 +1056,7 @@ class Params {
      * Used by csv_file_atom_feature.
      */
     @RuntimeParam
-    List<String> csv_file_feature_directories = [];
+    List<String> feat_csv_directories = [];
 
 //===========================================================================================================//
 


### PR DESCRIPTION
Implementation of a CSV feature that is able to load atom/residue feature values from external CSV files.

The basic idea is to allow a user to load a custom feature from an external file. From this perspective, it is very similar to conservation, but the aim here is to be more general and thus decrease the entry barrier for the development of new features.

The feature is called *csv_file_atom_feature* and must be added to extra features in order to be used. Next user must provide directories where the CSV files are located using *csv_file_feature_directories* options. 

The whole command may then look like this:
```
traineval -t .\datasets\chen11.ds -e .\datasets\joined(mlig).ds -extra_features 'csv_file_atom_feature'  -csv_file_feature_directories ',.\custom-feature,' 
```
Multiple directories may be provided as a list. The commas in the argument are used as the command-line parser ignore the first and last character in the command line argument - also by default, it considers dot to be a separator, which is obviously not optimal for paths.
 
In the directory, there must be a file for each PDB structure. For example, if there is 
a PDB file called ```148lE.pdb``` then a file called ```148lE.pdb.csv``` must be in the directory.

The file must be a valid CSV file with the following header:
```"chain","ins. code","seq. code","{feature-name}"```
where {feature-name} can any valid column name (the value is not used).
The ```chain```, ```ins. code``` and ```seq.code``` columns are used to identify the residue.

The reader also supports per-atom features by using the following header 
```"pdb serial","{feature-name}"```, where *pdb serial* refer to atom's serial number in the PDB file.

It is also possible to provide multiple value columns, with custom names, in a single file.

In case of an error, the feature throws the exception, the exception is logged but does not stop the execution - not even with ```-failFast 1```. So that may be an improvement to be made.



